### PR TITLE
ESP8266 Support

### DIFF
--- a/DMD2.h
+++ b/DMD2.h
@@ -280,6 +280,7 @@ private:
   byte pin_clk;
   byte pin_r_data;
 };
+#endif
 
 class DMD_TextBox : public Print {
 public:
@@ -302,7 +303,6 @@ private:
   int16_t cur_y;
   bool pending_newline;
 };
-#endif
 
 // Six byte header at beginning of FontCreator font structure, stored in PROGMEM
 struct FontHeader {

--- a/DMD2.h
+++ b/DMD2.h
@@ -141,7 +141,7 @@ class DMDFrame
 
   void drawString(int x, int y, const char *bChars, DMDGraphicsMode mode=GRAPHICS_ON, const uint8_t *font = NULL);
   void drawString(int x, int y, const String &str, DMDGraphicsMode mode=GRAPHICS_ON, const uint8_t *font = NULL);
-#ifdef __AVR__
+#if defined(__AVR__) || defined(ESP8266)
   void drawString_P(int x, int y, const char *flashStr, DMDGraphicsMode mode=GRAPHICS_ON, const uint8_t *font = NULL);
   inline void drawString(int x, int y, const __FlashStringHelper *flashStr, DMDGraphicsMode mode=GRAPHICS_ON, const uint8_t *font = NULL) {
     return drawString_P(x,y,(const char*)flashStr, mode, font);
@@ -152,7 +152,7 @@ class DMDFrame
   int charWidth(const char letter, const uint8_t *font = NULL);
 
   //Find the width of a string (width of all characters plus 1 pixel "kerning" between each character)
-#ifdef __AVR__
+#if defined(__AVR__) || defined(ESP8266)
   unsigned int stringWidth_P(const char *flashStr, const uint8_t *font = NULL);
   inline unsigned int stringWidth(const __FlashStringHelper *flashStr, const uint8_t *font = NULL) {
     return stringWidth_P((const char*)flashStr, font);
@@ -262,6 +262,9 @@ protected:
   void writeSPIData(volatile uint8_t *rows[4], const int rowsize);
 };
 
+#ifdef ESP8266
+// No SoftDMD for ESP8266 for now
+#else
 class SoftDMD : public BaseDMD
 {
 public:
@@ -299,6 +302,7 @@ private:
   int16_t cur_y;
   bool pending_newline;
 };
+#endif
 
 // Six byte header at beginning of FontCreator font structure, stored in PROGMEM
 struct FontHeader {

--- a/DMD2_Text.cpp
+++ b/DMD2_Text.cpp
@@ -153,7 +153,7 @@ template <class StrType> __attribute__((always_inline)) inline unsigned int _str
 }
 
 
-#ifdef __AVR__
+#if defined(__AVR__) || defined (ESP8266)
 // Small wrapper class to allow indexing of progmem strings via [] (should be inlined out of the actual implementation)
 class _FlashStringWrapper {
   const char *str;

--- a/DMD2_Timer.cpp
+++ b/DMD2_Timer.cpp
@@ -141,9 +141,9 @@ void BaseDMD::begin()
   timer1_attachInterrupt(scan_running_dmds);
   timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);
 #if defined(F_CPU) && (F_CPU == 160000000L)
-  timer1_write(50000); // 50000 ticks = ~5ms with /16 divider at 160MHz
+  timer1_write(5000); // 5000 ticks
 #else
-  timer1_write(25000); // 25000 ticks = ~5ms with /16 divider at 80MHz
+  timer1_write(2500); // 2500 ticks seems to work nicely for no flicker.
 #endif
 }
 

--- a/DMD2_Timer.cpp
+++ b/DMD2_Timer.cpp
@@ -33,7 +33,7 @@
 
 //#define NO_TIMERS
 
-#define ESP8266_TIMER0_TICKS 100000 //Number of ticks between DMD refreshes on the ESP8266, theoretically, there are 80 ticks per microsecond, 
+#define ESP8266_TIMER0_TICKS microsecondsToClockCycles(1000) // 1000 microseconds between calls to scan_running_dmds seems to work well.
 
 #ifdef NO_TIMERS
 

--- a/fonts/Arial14.h
+++ b/fonts/Arial14.h
@@ -39,6 +39,8 @@
 #include <inttypes.h>
 #ifdef __AVR__
 #include <avr/pgmspace.h>
+#elif defined (ESP8266)
+#include <pgmspace.h>
 #else
 #define PROGMEM
 #endif

--- a/fonts/Arial_Black_16.h
+++ b/fonts/Arial_Black_16.h
@@ -37,6 +37,8 @@
 #include <inttypes.h>
 #ifdef __AVR__
 #include <avr/pgmspace.h>
+#elif defined (ESP8266)
+#include <pgmspace.h>
 #else
 #define PROGMEM
 #endif

--- a/fonts/Droid_Sans_12.h
+++ b/fonts/Droid_Sans_12.h
@@ -39,6 +39,8 @@
 #include <inttypes.h>
 #ifdef __AVR__
 #include <avr/pgmspace.h>
+#elif defined (ESP8266)
+#include <pgmspace.h>
 #else
 #define PROGMEM
 #endif

--- a/fonts/Droid_Sans_16.h
+++ b/fonts/Droid_Sans_16.h
@@ -39,6 +39,8 @@
 #include <inttypes.h>
 #ifdef __AVR__
 #include <avr/pgmspace.h>
+#elif defined (ESP8266)
+#include <pgmspace.h>
 #else
 #define PROGMEM
 #endif

--- a/fonts/Droid_Sans_24.h
+++ b/fonts/Droid_Sans_24.h
@@ -39,6 +39,8 @@
 #include <inttypes.h>
 #ifdef __AVR__
 #include <avr/pgmspace.h>
+#elif defined (ESP8266)
+#include <pgmspace.h>
 #else
 #define PROGMEM
 #endif

--- a/fonts/SystemFont5x7.h
+++ b/fonts/SystemFont5x7.h
@@ -32,6 +32,8 @@
 #include <inttypes.h>
 #ifdef __AVR__
 #include <avr/pgmspace.h>
+#elif defined (ESP8266)
+#include <pgmspace.h>
 #else
 #define PROGMEM
 #endif

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Updated (beta) library for Freetronics DMD dot matrix displays.
 paragraph=Supports graphics operations (test, images, etc.) Still experimental, the stable library is called called "DMD"
 category=Display
 url=https://github.com/freetronics/DMD2/
-architectures=avr,sam
+architectures=avr,sam,esp8266


### PR DESCRIPTION
SoftDMD is not included, yet, but otherwise this is feature complete. (I've used a preprocessor statement to disable SoftDMD on the ESP8266)

All demo sketches compile and execute as they were meant to, the only change needed being changing SoftDMD to SPIDMD.

The `#define ESP8266_TIMER0_TICKS` in DMD2_Timer.cpp sets the delay between running `scan_running_dmds` via timer0 interrupt in microseconds, the default I've set is 1000, seems to work well with 4mhz SPI clock, which is also a default.

Why timer0?
Because the ESP8266 has no hardware PWM, so the ESP8266/Arduino project is using timer1 for software PWM, a.k.a analogWrite. The only other ESP8266 library that currently uses timer0 is for Servo control, the likelihood that someone will use servos with a DMD is low compared to wanting to be able to adjust DMD brightness.

How to connect:
You'll probably want to use a level shifter, I used a TXS0108E that worked quite well. I imagine some 7400 and 4000 series chips that have been used in such a way before could also be substituted.

| Pin on DMD | GPIO # on ESP |
| --- | --- |
| a | GPIO16 |
| b | GPIO12 |
| sck | GPIO0 |
| clk | GPIO14 |
| r | GPIO13 |
| noe | GPIO15 |

One more thing: The kinds of frequencies everything is required to run at to make this work probably doesn't lend itself too well to a solderless breadboard, my ESP8266 is on a soldered breadboard and it works pretty well, but sometimes it hiccups due to the capacitance between the tracks on the board, people are welcome to try, but I thought you should know the potential risks of using a solderless breadboard.

EDIT: Swapped GPIO15 from sck to noe, swapped GPIO0 from noe to sck, I apologise for the change, putting noe on gpio15 (which is held low for the ESP8266's boot mode) keeps the DMD from displaying garbage while the ESP8266 boots.

See https://github.com/esp8266/Arduino for more details.
