### PR TITLE
Update DMD2.h

### DIFF
--- a/DMD2.h
+++ b/DMD2.h
@@ -98,7 +98,7 @@ class DMDFrame
 {
   friend class DMD_TextBox;
  public:
-  DMDFrame(byte pixelsWide, byte pixelsHigh);
+  DMDFrame(uint16_t pixelsWide, uint16_t pixelsHigh);
   DMDFrame(const DMDFrame &source);
   virtual ~DMDFrame();
 
@@ -168,10 +168,10 @@ class DMDFrame
 
   void swapBuffers(DMDFrame &other);
 
-  const byte width; // in pixels
-  const byte height; // in pixels
+  const uint16_t width; // in pixels
+  const uint16_t height; // in pixels
  protected:
-  volatile uint8_t *bitmap;
+  volatile uint8_t *bitmap;uint16_t
   byte row_width_bytes; // width in bitmap, bit-per-pixel rounded up to nearest byte
   byte height_in_panels; // in panels
 


### PR DESCRIPTION
Changed the datatype of pixelswide, pixelsHigh, width and height from byte to uint16_t, so that the library could work for more than 7 display boards in single row.